### PR TITLE
test semicolon positions

### DIFF
--- a/cases/semicolons.css
+++ b/cases/semicolons.css
@@ -5,5 +5,6 @@ a {;;
 
 aaa{b:c;}
 a{b:cc};
+a{b:c} ;
 @a bbbb;
 /*     ^ */

--- a/cases/semicolons.css
+++ b/cases/semicolons.css
@@ -2,3 +2,8 @@ a {;;
     color: black;
     ; ;
 }
+
+aaa{b:c;}
+a{b:cc};
+@a bbbb;
+/*     ^ */

--- a/cases/semicolons.json
+++ b/cases/semicolons.json
@@ -129,9 +129,9 @@
       ],
       "source": {
         "end": {
-          "column": 7,
+          "column": 8,
           "line": 7,
-          "offset": 52
+          "offset": 53
         },
         "start": {
           "column": 1,

--- a/cases/semicolons.json
+++ b/cases/semicolons.json
@@ -1,6 +1,6 @@
 {
   "raws": {
-    "semicolon": false,
+    "semicolon": true,
     "after": ""
   },
   "type": "root",
@@ -49,13 +49,147 @@
         }
       },
       "selector": "a"
+    },
+    {
+      "raws": {
+        "before": "\n\n",
+        "between": "",
+        "semicolon": true,
+        "after": ""
+      },
+      "type": "rule",
+      "nodes": [
+        {
+          "raws": {
+            "before": "",
+            "between": ":"
+          },
+          "type": "decl",
+          "source": {
+            "end": {
+              "column": 8,
+              "line": 6,
+              "offset": 43
+            },
+            "start": {
+              "column": 5,
+              "line": 6,
+              "offset": 39
+            }
+          },
+          "prop": "b",
+          "value": "c"
+        }
+      ],
+      "source": {
+        "end": {
+          "column": 9,
+          "line": 6,
+          "offset": 44
+        },
+        "start": {
+          "column": 1,
+          "line": 6,
+          "offset": 35
+        }
+      },
+      "selector": "aaa"
+    },
+    {
+      "raws": {
+        "before": "\n",
+        "between": "",
+        "semicolon": false,
+        "after": "",
+        "ownSemicolon": ";"
+      },
+      "type": "rule",
+      "nodes": [
+        {
+          "raws": {
+            "before": "",
+            "between": ":"
+          },
+          "type": "decl",
+          "source": {
+            "end": {
+              "column": 6,
+              "line": 7,
+              "offset": 51
+            },
+            "start": {
+              "column": 3,
+              "line": 7,
+              "offset": 47
+            }
+          },
+          "prop": "b",
+          "value": "cc"
+        }
+      ],
+      "source": {
+        "end": {
+          "column": 7,
+          "line": 7,
+          "offset": 52
+        },
+        "start": {
+          "column": 1,
+          "line": 7,
+          "offset": 45
+        }
+      },
+      "selector": "a"
+    },
+    {
+      "raws": {
+        "before": "\n",
+        "between": "",
+        "afterName": " "
+      },
+      "type": "atrule",
+      "name": "a",
+      "source": {
+        "end": {
+          "column": 8,
+          "line": 8,
+          "offset": 62
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+          "offset": 54
+        }
+      },
+      "params": "bbbb"
+    },
+    {
+      "raws": {
+        "before": "\n",
+        "left": "     ",
+        "right": " "
+      },
+      "type": "comment",
+      "source": {
+        "end": {
+          "column": 11,
+          "line": 9,
+          "offset": 74
+        },
+        "start": {
+          "column": 1,
+          "line": 9,
+          "offset": 63
+        }
+      },
+      "text": "^"
     }
   ],
   "source": {
     "end": {
-      "column": 2,
-      "line": 4,
-      "offset": 33
+      "column": 12,
+      "line": 9,
+      "offset": 74
     },
     "start": {
       "column": 1,

--- a/cases/semicolons.json
+++ b/cases/semicolons.json
@@ -145,6 +145,52 @@
       "raws": {
         "before": "\n",
         "between": "",
+        "semicolon": false,
+        "after": "",
+        "ownSemicolon": " ;"
+      },
+      "type": "rule",
+      "nodes": [
+        {
+          "raws": {
+            "before": "",
+            "between": ":"
+          },
+          "type": "decl",
+          "source": {
+            "end": {
+              "column": 5,
+              "line": 8,
+              "offset": 59
+            },
+            "start": {
+              "column": 3,
+              "line": 8,
+              "offset": 56
+            }
+          },
+          "prop": "b",
+          "value": "c"
+        }
+      ],
+      "source": {
+        "end": {
+          "column": 8,
+          "line": 8,
+          "offset": 63
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+          "offset": 54
+        }
+      },
+      "selector": "a"
+    },
+    {
+      "raws": {
+        "before": "\n",
+        "between": "",
         "afterName": " "
       },
       "type": "atrule",
@@ -152,13 +198,13 @@
       "source": {
         "end": {
           "column": 8,
-          "line": 8,
-          "offset": 62
+          "line": 9,
+          "offset": 71
         },
         "start": {
           "column": 1,
-          "line": 8,
-          "offset": 54
+          "line": 9,
+          "offset": 63
         }
       },
       "params": "bbbb"
@@ -173,13 +219,13 @@
       "source": {
         "end": {
           "column": 11,
-          "line": 9,
-          "offset": 74
+          "line": 10,
+          "offset": 83
         },
         "start": {
           "column": 1,
-          "line": 9,
-          "offset": 63
+          "line": 10,
+          "offset": 72
         }
       },
       "text": "^"
@@ -188,8 +234,8 @@
   "source": {
     "end": {
       "column": 12,
-      "line": 9,
-      "offset": 74
+      "line": 10,
+      "offset": 83
     },
     "start": {
       "column": 1,


### PR DESCRIPTION
I found that PostCSS currently is inconsistent in determining the end positions of nodes in the original source when nodes have a semicolon at the end.

In the first commit I used the values as currently used by PostCSS.
In the second commit I've set the values as what I would expect them to be.